### PR TITLE
Fix phone number format in insurance provider seed data

### DIFF
--- a/backend/dist/utils/seedData.js
+++ b/backend/dist/utils/seedData.js
@@ -13,7 +13,7 @@ const sampleInsuranceProviders = [
         states: ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
         planTypes: ['HMO', 'PPO', 'EPO', 'POS'],
         contactInfo: {
-            phone: '1-800-810-BLUE',
+            phone: '1-800-810-2583',
             website: 'https://www.bcbs.com',
             customerService: '1-800-810-2583'
         },

--- a/backend/src/utils/seedData.ts
+++ b/backend/src/utils/seedData.ts
@@ -8,7 +8,7 @@ const sampleInsuranceProviders = [
     states: ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA', 'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY'],
     planTypes: ['HMO', 'PPO', 'EPO', 'POS'],
     contactInfo: {
-      phone: '1-800-810-BLUE',
+      phone: '1-800-810-2583',
       website: 'https://www.bcbs.com',
       customerService: '1-800-810-2583'
     },


### PR DESCRIPTION
## Summary
- replace alphanumeric toll-free number with numeric digits in Blue Cross Blue Shield seed entry
- update compiled seed data to match new phone format

## Testing
- `npm run build` *(fails: src/controllers/uploadController.ts ...)*
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: 102 errors, e.g. Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_688ee1531838833097a78e91c24f4acb