### PR TITLE
Load env config before server imports

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,3 +1,4 @@
+import './config/env';
 import express from 'express';
 import cors from 'cors';
 import helmet from 'helmet';
@@ -6,8 +7,6 @@ import morgan from 'morgan';
 import rateLimit from 'express-rate-limit';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
-import dotenv from 'dotenv';
-import path from 'path';
 
 import { connectDatabase } from './config/database';
 import { connectRedis } from './config/redis';
@@ -26,8 +25,7 @@ import notificationRoutes from './routes/notification';
 import insuranceRoutes from './routes/insurance';
 import uploadRoutes from './routes/upload';
 
-// Load environment variables
-dotenv.config({ path: path.resolve(__dirname, '../.env') });
+// Verify environment variables
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY;
 if (googleMapsApiKey) {
   console.log('✅ GOOGLE_MAPS_API_KEY loaded');


### PR DESCRIPTION
## Summary
- Load environment variables at startup by importing `config/env` before other server modules
- Remove redundant dotenv initialization, preventing false "GOOGLE_MAPS_API_KEY not set" warnings

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: 102 errors)*
- `npm run build` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688ee2f74dd88330b36c6606e6693dea