### PR TITLE
feat: improve triage urgency and location detection

### DIFF
--- a/backend/src/controllers/locationController.ts
+++ b/backend/src/controllers/locationController.ts
@@ -1,0 +1,69 @@
+import { Request, Response, NextFunction } from 'express';
+import mapsService from '../services/mapsService';
+
+// Get human readable address from coordinates
+export const reverseGeocode = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { lat, lng } = req.query;
+    if (!lat || !lng) {
+      return res.status(400).json({ success: false, error: 'lat and lng are required' });
+    }
+
+    const address = await mapsService.reverseGeocode(parseFloat(lat as string), parseFloat(lng as string));
+    return res.status(200).json({ success: true, address });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// Find nearby emergency facilities (hospitals or urgent care) around coordinates
+export const getEmergencyFacilities = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { lat, lng } = req.query;
+    if (!lat || !lng) {
+      return res.status(400).json({ success: false, error: 'lat and lng are required' });
+    }
+
+    const location = {
+      lat: parseFloat(lat as string),
+      lng: parseFloat(lng as string)
+    };
+
+    const places = await mapsService.findNearbyPlaces({
+      location,
+      radius: 10000,
+      type: 'hospital',
+      keyword: 'emergency'
+    });
+
+    const facilities = await Promise.all(places.slice(0, 5).map(async place => {
+      let phone = '';
+      try {
+        const details = await mapsService.getPlaceDetails(place.placeId);
+        phone = details.phone || '';
+      } catch (err) {
+        // ignore
+      }
+
+      const distanceKm = mapsService.calculateDistance(location.lat, location.lng, place.location.lat, place.location.lng);
+      const eta = Math.round((distanceKm / 50) * 60); // assume 50km/h average speed
+
+      return {
+        id: place.placeId,
+        name: place.name,
+        type: place.types?.includes('hospital') ? 'hospital' : 'urgent_care',
+        address: place.address,
+        phone,
+        distance: Math.round(distanceKm * 10) / 10,
+        eta,
+        availability: 'medium',
+        specialties: []
+      };
+    }));
+
+    res.status(200).json({ success: true, facilities });
+  } catch (error) {
+    next(error);
+  }
+};
+

--- a/backend/src/routes/location.ts
+++ b/backend/src/routes/location.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { reverseGeocode, getEmergencyFacilities } from '../controllers/locationController';
+
+const router = Router();
+
+router.get('/reverse-geocode', reverseGeocode);
+router.get('/emergency', getEmergencyFacilities);
+
+export default router;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,6 +24,7 @@ import medicalHistoryRoutes from './routes/medicalHistory';
 import notificationRoutes from './routes/notification';
 import insuranceRoutes from './routes/insurance';
 import uploadRoutes from './routes/upload';
+import locationRoutes from './routes/location';
 
 // Verify environment variables
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY;
@@ -84,6 +85,7 @@ app.use('/api/medical-history', medicalHistoryRoutes);
 app.use('/api/notifications', notificationRoutes);
 app.use('/api/insurance', insuranceRoutes);
 app.use('/api/upload', uploadRoutes);
+app.use('/api/location', locationRoutes);
 
 // WebSocket connection handling
 io.on('connection', (socket) => {

--- a/src/pages/EmergencyMode.tsx
+++ b/src/pages/EmergencyMode.tsx
@@ -1,16 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { 
-  AlertTriangle, 
-  Phone, 
-  MapPin, 
-  Navigation, 
-  Clock, 
+import {
+  AlertTriangle,
+  Phone,
+  MapPin,
+  Navigation,
+  Clock,
   Heart,
   Zap,
   Car,
   Shield,
   ChevronRight
 } from 'lucide-react';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
 
 interface EmergencyFacility {
   id: string;
@@ -27,54 +29,31 @@ interface EmergencyFacility {
 const EmergencyMode: React.FC = () => {
   const [userLocation, setUserLocation] = useState<{ lat: number; lng: number } | null>(null);
   const [locationError, setLocationError] = useState<string | null>(null);
-  const [emergencyFacilities] = useState<EmergencyFacility[]>([
-    {
-      id: '1',
-      name: 'Manhattan General Hospital ER',
-      type: 'hospital',
-      address: '123 Medical Center Dr, New York, NY 10001',
-      phone: '+1-555-0101',
-      distance: 1.2,
-      eta: 8,
-      availability: 'medium',
-      specialties: ['Emergency Medicine', 'Trauma', 'Cardiology']
-    },
-    {
-      id: '2',
-      name: 'NYC Emergency Medical Center',
-      type: 'hospital',
-      address: '456 Emergency Ave, New York, NY 10002',
-      phone: '+1-555-0102',
-      distance: 2.1,
-      eta: 12,
-      availability: 'high',
-      specialties: ['Emergency Medicine', 'Pediatric Emergency', 'Neurology']
-    },
-    {
-      id: '3',
-      name: 'CityMed Urgent Care',
-      type: 'urgent_care',
-      address: '789 Health Plaza, New York, NY 10003',
-      phone: '+1-555-0103',
-      distance: 0.8,
-      eta: 5,
-      availability: 'high',
-      specialties: ['Urgent Care', 'Minor Emergency', 'X-Ray']
-    }
-  ]);
+  const [emergencyFacilities, setEmergencyFacilities] = useState<EmergencyFacility[]>([]);
 
   useEffect(() => {
     // Get user's current location
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setUserLocation({
+        async (position) => {
+          const coords = {
             lat: position.coords.latitude,
             lng: position.coords.longitude
-          });
+          };
+          setUserLocation(coords);
+
+          try {
+            const response = await fetch(`${API_BASE_URL}/location/emergency?lat=${coords.lat}&lng=${coords.lng}`);
+            const data = await response.json();
+            if (data.success) {
+              setEmergencyFacilities(data.facilities);
+            }
+          } catch (err) {
+            console.error('Failed to fetch emergency facilities', err);
+          }
         },
         (error) => {
-          setLocationError('Unable to get your location. Using default location.');
+          setLocationError('Unable to get your location.');
           console.error('Geolocation error:', error);
         }
       );
@@ -181,7 +160,7 @@ const EmergencyMode: React.FC = () => {
           <div className="flex items-center justify-between">
             <h2 className="text-2xl font-bold text-gray-900">Nearest Emergency Care</h2>
             <div className="text-sm text-gray-600">
-              {userLocation ? 'Based on your location' : 'Default location: New York, NY'}
+              {userLocation ? 'Based on your location' : 'Waiting for location...'}
             </div>
           </div>
 

--- a/src/pages/SymptomForm.tsx
+++ b/src/pages/SymptomForm.tsx
@@ -90,6 +90,26 @@ const SymptomForm: React.FC = () => {
     }
   }, [user]);
 
+  // Attempt to auto-detect user location if not already set
+  useEffect(() => {
+    if (!formData.location && navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(async (position) => {
+        try {
+          const { latitude, longitude } = position.coords;
+          const response = await fetch(`${API_BASE_URL}/location/reverse-geocode?lat=${latitude}&lng=${longitude}`);
+          const data = await response.json();
+          if (data.success && data.address) {
+            setFormData(prev => ({ ...prev, location: data.address }));
+          }
+        } catch (err) {
+          console.error('Failed to fetch address from coordinates', err);
+        }
+      }, (error) => {
+        console.error('Geolocation error:', error);
+      });
+    }
+  }, [formData.location]);
+
   const searchInsuranceProviders = async (query: string) => {
     if (!query.trim()) {
       setInsuranceProviders([]);

--- a/src/pages/TriageResults.tsx
+++ b/src/pages/TriageResults.tsx
@@ -34,27 +34,39 @@ const TriageResults: React.FC = () => {
     }
 
     const data = JSON.parse(symptomData);
-    
+
     // Mock AI triage analysis based on symptoms
     setTimeout(() => {
+      const inferredUrgency = determineUrgency(data);
       const mockResult: TriageResult = {
-        urgency: data.urgency,
-        recommendation: getRecommendation(data),
+        urgency: inferredUrgency,
+        recommendation: getRecommendation(inferredUrgency),
         reasoning: getReasoning(data),
-        careType: getCareType(data),
-        timeframe: getTimeframe(data),
+        careType: getCareType(inferredUrgency),
+        timeframe: getTimeframe(inferredUrgency),
         confidence: 89
       };
-      
+
       setTriageResult(mockResult);
       setLoading(false);
     }, 3000);
   }, [navigate]);
 
-  const getRecommendation = (data: any): string => {
-    if (data.severity >= 8 || data.urgency === 'emergency') {
+  const determineUrgency = (data: any): 'emergency' | 'urgent' | 'routine' => {
+    const symptoms = data.symptoms.toLowerCase();
+    if (symptoms.includes('chest pain') || symptoms.includes('difficulty breathing')) {
+      return 'emergency';
+    }
+    if (data.severity >= 7) {
+      return 'urgent';
+    }
+    return 'routine';
+  };
+
+  const getRecommendation = (urgency: string): string => {
+    if (urgency === 'emergency') {
       return 'Seek immediate emergency care';
-    } else if (data.severity >= 6 || data.urgency === 'urgent') {
+    } else if (urgency === 'urgent') {
       return 'Visit urgent care within 24 hours';
     } else {
       return 'Schedule routine appointment with primary care';
@@ -72,15 +84,15 @@ const TriageResults: React.FC = () => {
     }
   };
 
-  const getCareType = (data: any): string => {
-    if (data.urgency === 'emergency') return 'Emergency Room';
-    if (data.urgency === 'urgent') return 'Urgent Care Center';
+  const getCareType = (urgency: string): string => {
+    if (urgency === 'emergency') return 'Emergency Room';
+    if (urgency === 'urgent') return 'Urgent Care Center';
     return 'Primary Care Clinic';
   };
 
-  const getTimeframe = (data: any): string => {
-    if (data.urgency === 'emergency') return 'Immediate';
-    if (data.urgency === 'urgent') return 'Within 24 hours';
+  const getTimeframe = (urgency: string): string => {
+    if (urgency === 'emergency') return 'Immediate';
+    if (urgency === 'urgent') return 'Within 24 hours';
     return 'Within 1-2 weeks';
   };
 


### PR DESCRIPTION
## Summary
- infer triage urgency from symptoms and severity instead of user-selected urgency
- auto-detect user location and fetch reverse geocoded address
- serve nearby emergency facilities using new location endpoints and client integration

## Testing
- `npm test --prefix backend` *(fails: No tests found)*
- `npm run lint --prefix backend` *(fails: 103 errors)*
- `npm run lint` *(fails: 206 errors)*


------
https://chatgpt.com/codex/tasks/task_e_688ee651bd68833096407fe880336d72