### PR TITLE
Implement clinic filtering

### DIFF
--- a/src/contexts/ClinicContext.tsx
+++ b/src/contexts/ClinicContext.tsx
@@ -36,6 +36,7 @@ interface SearchFilters {
   insurance: string;
   urgency: 'emergency' | 'urgent' | 'routine';
   maxDistance: number;
+  minRating: number;
 }
 
 const ClinicContext = createContext<ClinicContextType | undefined>(undefined);
@@ -118,9 +119,21 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     if (filters.urgency === 'emergency') {
       filtered = filtered.filter(clinic => clinic.emergencyServices);
     } else if (filters.urgency === 'urgent') {
-      filtered = filtered.filter(clinic => 
+      filtered = filtered.filter(clinic =>
         clinic.type === 'urgent_care' || clinic.emergencyServices
       );
+    }
+
+    // Filter by insurance
+    if (filters.insurance && filters.insurance !== 'any') {
+      filtered = filtered.filter(clinic =>
+        clinic.insuranceAccepted.includes(filters.insurance)
+      );
+    }
+
+    // Filter by rating
+    if (filters.minRating && filters.minRating > 0) {
+      filtered = filtered.filter(clinic => clinic.rating >= filters.minRating);
     }
 
     // Filter by distance

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { 
-  MapPin, 
-  Star, 
-  Clock, 
-  Phone, 
-  Shield, 
+import {
+  MapPin,
+  Star,
+  Phone,
+  Shield,
   Filter,
   ChevronDown,
   Navigation,
@@ -25,21 +24,41 @@ const SearchResults: React.FC = () => {
     insurance: 'any',
     specialty: 'any'
   });
+  const [searchParams, setSearchParams] = useState<{
+    location: string;
+    urgency: 'emergency' | 'urgent' | 'routine';
+  } | null>(null);
 
   useEffect(() => {
     // Get search data from previous page
     const symptomData = sessionStorage.getItem('symptomData');
     if (symptomData) {
       const data = JSON.parse(symptomData);
+      setSearchParams({ location: data.location, urgency: data.urgency });
+      setFilters(prev => ({ ...prev, insurance: data.insurance || 'any' }));
       searchClinics({
         location: data.location,
         specialty: 'any',
-        insurance: data.insurance,
+        insurance: data.insurance || 'any',
         urgency: data.urgency,
-        maxDistance: 10
+        maxDistance: 10,
+        minRating: 0
       });
     }
   }, [searchClinics]);
+
+  useEffect(() => {
+    if (searchParams) {
+      searchClinics({
+        location: searchParams.location,
+        specialty: filters.specialty,
+        insurance: filters.insurance,
+        urgency: searchParams.urgency,
+        maxDistance: filters.maxDistance,
+        minRating: filters.minRating
+      });
+    }
+  }, [filters, searchClinics, searchParams]);
 
   const handleBooking = (clinic: Clinic) => {
     setSelectedClinic(clinic);


### PR DESCRIPTION
## Summary
- add support for filtering clinics by distance, rating, insurance, and specialty
- reapply clinic searches when filters change so results update in real time

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 208 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688eeaa43ae08330b6329552104149ac