### PR TITLE
Add location-aware clinic search and self-care guidance

### DIFF
--- a/src/contexts/ClinicContext.tsx
+++ b/src/contexts/ClinicContext.tsx
@@ -32,6 +32,7 @@ interface ClinicContextType {
 
 interface SearchFilters {
   location: string;
+  userLocation?: { lat: number; lng: number };
   specialty: string;
   insurance: string;
   urgency: 'emergency' | 'urgent' | 'routine';
@@ -103,7 +104,25 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
 
   const searchClinics = (filters: SearchFilters) => {
-    let filtered = [...clinics];
+    // Recalculate distances based on user's location if provided
+    const processed = clinics.map(clinic => {
+      let distance = clinic.distance;
+      if (filters.userLocation) {
+        const toRad = (value: number) => (value * Math.PI) / 180;
+        const R = 3958.8; // Earth radius in miles
+        const dLat = toRad(clinic.location.lat - filters.userLocation.lat);
+        const dLng = toRad(clinic.location.lng - filters.userLocation.lng);
+        const a = Math.sin(dLat / 2) ** 2 +
+          Math.cos(toRad(filters.userLocation.lat)) *
+          Math.cos(toRad(clinic.location.lat)) *
+          Math.sin(dLng / 2) ** 2;
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        distance = parseFloat((R * c).toFixed(1));
+      }
+      return { ...clinic, distance };
+    });
+
+    let filtered = [...processed];
 
     // Filter by specialty
     if (filters.specialty && filters.specialty !== 'any') {

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { 
-  MapPin, 
-  Star, 
-  Clock, 
-  Phone, 
-  Shield, 
+import {
+  MapPin,
+  Star,
+  Phone,
+  Shield,
   Filter,
   ChevronDown,
   Navigation,
@@ -33,6 +32,7 @@ const SearchResults: React.FC = () => {
       const data = JSON.parse(symptomData);
       searchClinics({
         location: data.location,
+        userLocation: data.coordinates,
         specialty: 'any',
         insurance: data.insurance,
         urgency: data.urgency,

--- a/src/pages/SymptomForm.tsx
+++ b/src/pages/SymptomForm.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { 
-  MapPin, 
-  Heart, 
-  User, 
-  Calendar, 
-  ChevronRight, 
+import {
+  MapPin,
+  Heart,
+  ChevronRight,
   Mic,
   Shield,
   Clock,
@@ -25,6 +23,7 @@ interface FormData {
   duration: string;
   severity: number;
   location: string;
+  coordinates?: { lat: number; lng: number };
   insurance: string;
   preferredTime: string;
   urgency: 'routine' | 'urgent' | 'emergency';
@@ -56,6 +55,7 @@ const SymptomForm: React.FC = () => {
     duration: '',
     severity: 5,
     location: user?.location?.address || '',
+    coordinates: user?.location ? { lat: user.location.lat, lng: user.location.lng } : undefined,
     insurance: user?.insurance?.provider || '',
     preferredTime: 'morning',
     urgency: 'routine',
@@ -80,6 +80,7 @@ const SymptomForm: React.FC = () => {
       setFormData(prev => ({
         ...prev,
         location: user.location?.address || prev.location,
+        coordinates: user.location ? { lat: user.location.lat, lng: user.location.lng } : prev.coordinates,
         insurance: user.insurance?.provider || prev.insurance,
         medicalHistory: {
           allergies: user.medicalHistory?.allergies || [],
@@ -92,14 +93,18 @@ const SymptomForm: React.FC = () => {
 
   // Attempt to auto-detect user location if not already set
   useEffect(() => {
-    if (!formData.location && navigator.geolocation) {
+    if ((!formData.location || !formData.coordinates) && navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(async (position) => {
         try {
           const { latitude, longitude } = position.coords;
           const response = await fetch(`${API_BASE_URL}/location/reverse-geocode?lat=${latitude}&lng=${longitude}`);
           const data = await response.json();
           if (data.success && data.address) {
-            setFormData(prev => ({ ...prev, location: data.address }));
+            setFormData(prev => ({
+              ...prev,
+              location: data.address,
+              coordinates: { lat: latitude, lng: longitude }
+            }));
           }
         } catch (err) {
           console.error('Failed to fetch address from coordinates', err);
@@ -108,7 +113,7 @@ const SymptomForm: React.FC = () => {
         console.error('Geolocation error:', error);
       });
     }
-  }, [formData.location]);
+  }, [formData.location, formData.coordinates]);
 
   const searchInsuranceProviders = async (query: string) => {
     if (!query.trim()) {
@@ -732,7 +737,7 @@ const SymptomForm: React.FC = () => {
                           name="urgency"
                           value={urgency.value}
                           checked={formData.urgency === urgency.value}
-                          onChange={(e) => setFormData({ ...formData, urgency: e.target.value as any })}
+                        onChange={(e) => setFormData({ ...formData, urgency: e.target.value as 'routine' | 'urgent' | 'emergency' })}
                           className="sr-only"
                         />
                         <div className="text-center">

--- a/src/pages/TriageResults.tsx
+++ b/src/pages/TriageResults.tsx
@@ -18,6 +18,12 @@ interface TriageResult {
   careType: string;
   timeframe: string;
   confidence: number;
+  selfCare: string;
+}
+
+interface SymptomData {
+  symptoms: string;
+  severity: number;
 }
 
 const TriageResults: React.FC = () => {
@@ -44,7 +50,8 @@ const TriageResults: React.FC = () => {
         reasoning: getReasoning(data),
         careType: getCareType(inferredUrgency),
         timeframe: getTimeframe(inferredUrgency),
-        confidence: 89
+        confidence: 89,
+        selfCare: getSelfCareAdvice(data)
       };
 
       setTriageResult(mockResult);
@@ -52,7 +59,7 @@ const TriageResults: React.FC = () => {
     }, 3000);
   }, [navigate]);
 
-  const determineUrgency = (data: any): 'emergency' | 'urgent' | 'routine' => {
+  const determineUrgency = (data: SymptomData): 'emergency' | 'urgent' | 'routine' => {
     const symptoms = data.symptoms.toLowerCase();
     if (symptoms.includes('chest pain') || symptoms.includes('difficulty breathing')) {
       return 'emergency';
@@ -73,7 +80,7 @@ const TriageResults: React.FC = () => {
     }
   };
 
-  const getReasoning = (data: any): string => {
+  const getReasoning = (data: SymptomData): string => {
     const symptoms = data.symptoms.toLowerCase();
     if (symptoms.includes('chest pain') || symptoms.includes('difficulty breathing')) {
       return 'Symptoms suggest potential cardiovascular or respiratory issues that require immediate attention.';
@@ -94,6 +101,23 @@ const TriageResults: React.FC = () => {
     if (urgency === 'emergency') return 'Immediate';
     if (urgency === 'urgent') return 'Within 24 hours';
     return 'Within 1-2 weeks';
+  };
+
+  const getSelfCareAdvice = (data: SymptomData): string => {
+    const symptoms = data.symptoms.toLowerCase();
+    if (symptoms.includes('cut') || symptoms.includes('bleeding')) {
+      return 'Clean the wound with running water, apply gentle pressure to stop bleeding, and cover with a sterile bandage. Seek medical care if the cut is deep or does not stop bleeding.';
+    }
+    if (symptoms.includes('sprain') || symptoms.includes('swelling')) {
+      return 'Rest the injured area, apply ice wrapped in a cloth for 20 minutes, compress with an elastic bandage, and keep it elevated.';
+    }
+    if (symptoms.includes('fever')) {
+      return 'Stay hydrated, rest, and consider an over-the-counter fever reducer such as acetaminophen. Seek medical care if the fever is high or persistent.';
+    }
+    if (symptoms.includes('headache')) {
+      return 'Rest in a quiet, dark room and stay hydrated. Over-the-counter pain relief may help.';
+    }
+    return 'Rest, monitor your symptoms, and seek medical care if they worsen or do not improve.';
   };
 
   const getUrgencyColor = (urgency: string) => {
@@ -222,6 +246,15 @@ const TriageResults: React.FC = () => {
               </div>
             </div>
           </div>
+        </div>
+
+        {/* Self-Care Advice */}
+        <div className="bg-white rounded-2xl shadow-lg p-6 mb-8">
+          <h3 className="text-xl font-bold text-gray-900 mb-2 flex items-center space-x-2">
+            <Shield className="w-6 h-6 text-[#1D6FA3]" />
+            <span>Self-Care Suggestions</span>
+          </h3>
+          <p className="text-gray-700">{triageResult.selfCare}</p>
         </div>
 
         {/* Emergency Actions */}


### PR DESCRIPTION
## Summary
- capture user coordinates during symptom entry to enable location-aware features
- compute distances to clinics using user location and show nearby results
- provide contextual self-care suggestions in triage results

## Testing
- `npm run lint` *(fails: 203 problems, 201 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eec37d4748330a3bc6ecbc9717747