### PR TITLE
fix: stabilize clinic search and handle emergency fetch errors

### DIFF
--- a/src/contexts/ClinicContext.tsx
+++ b/src/contexts/ClinicContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, ReactNode, useCallback } from 'react';
 
 export interface Clinic {
   id: string;
@@ -104,7 +104,7 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
   const [filteredClinics, setFilteredClinics] = useState<Clinic[]>(mockClinics);
   const [selectedClinic, setSelectedClinic] = useState<Clinic | null>(null);
 
-  const searchClinics = (filters: SearchFilters) => {
+  const searchClinics = useCallback((filters: SearchFilters) => {
     // Recalculate distances based on user's location if provided
     const processed = clinics.map(clinic => {
       let distance = clinic.distance;
@@ -162,7 +162,7 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     filtered.sort((a, b) => a.distance - b.distance);
 
     setFilteredClinics(filtered);
-  };
+  }, [clinics]);
 
   return (
     <ClinicContext.Provider value={{

--- a/src/pages/EmergencyMode.tsx
+++ b/src/pages/EmergencyMode.tsx
@@ -44,6 +44,10 @@ const EmergencyMode: React.FC = () => {
 
           try {
             const response = await fetch(`${API_BASE_URL}/location/emergency?lat=${coords.lat}&lng=${coords.lng}`);
+            if (!response.ok) {
+              console.error('Emergency facilities request failed:', response.status);
+              return;
+            }
             const data = await response.json();
             if (data.success) {
               setEmergencyFacilities(data.facilities);


### PR DESCRIPTION
## Summary
- memoize `searchClinics` to stop infinite re-renders
- handle non-OK responses when fetching emergency facilities

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 205 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688ef1e938b08330b564080a834b69aa