### PR TITLE
Improve self-care guidance and provider search

### DIFF
--- a/src/contexts/ClinicContext.tsx
+++ b/src/contexts/ClinicContext.tsx
@@ -96,6 +96,42 @@ const mockClinics: Clinic[] = [
     coveragePercentage: 95,
     estimatedCost: 120,
     image: 'https://images.pexels.com/photos/4021775/pexels-photo-4021775.jpeg'
+  },
+  {
+    id: '4',
+    name: "St. Michael's Hospital",
+    type: 'hospital',
+    address: '30 Bond St, Toronto, ON M5B 1W8',
+    phone: '+1-416-360-4000',
+    location: { lat: 43.6548, lng: -79.3784 },
+    distance: 2.3,
+    rating: 4.4,
+    reviews: 900,
+    insuranceAccepted: ['OHIP', 'Sun Life', 'Manulife'],
+    availableSlots: ['2024-01-17T09:00', '2024-01-17T15:30', '2024-01-18T11:00'],
+    specialties: ['Emergency Medicine', 'Trauma'],
+    emergencyServices: true,
+    coveragePercentage: 88,
+    estimatedCost: 400,
+    image: 'https://images.pexels.com/photos/263402/pexels-photo-263402.jpeg'
+  },
+  {
+    id: '5',
+    name: 'Sunnybrook Health Sciences Centre',
+    type: 'hospital',
+    address: '2075 Bayview Ave, Toronto, ON M4N 3M5',
+    phone: '+1-416-480-6100',
+    location: { lat: 43.725, lng: -79.378 },
+    distance: 5.2,
+    rating: 4.5,
+    reviews: 1100,
+    insuranceAccepted: ['OHIP', 'Sun Life', 'Manulife'],
+    availableSlots: ['2024-01-18T09:00', '2024-01-18T14:00', '2024-01-19T10:30'],
+    specialties: ['Emergency Medicine', 'Cardiology'],
+    emergencyServices: true,
+    coveragePercentage: 80,
+    estimatedCost: 500,
+    image: 'https://images.pexels.com/photos/236380/pexels-photo-236380.jpeg'
   }
 ];
 
@@ -158,8 +194,14 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     // Filter by distance
     filtered = filtered.filter(clinic => clinic.distance <= filters.maxDistance);
 
-    // Sort by distance
-    filtered.sort((a, b) => a.distance - b.distance);
+    // Ensure at least 5 results by supplementing with closest clinics
+    if (filtered.length < 5) {
+      const sortedByDistance = [...processed].sort((a, b) => a.distance - b.distance);
+      filtered = sortedByDistance.slice(0, 5);
+    } else {
+      // Sort by distance when enough results
+      filtered.sort((a, b) => a.distance - b.distance);
+    }
 
     setFilteredClinics(filtered);
   }, [clinics]);

--- a/src/pages/SearchResults.tsx
+++ b/src/pages/SearchResults.tsx
@@ -35,17 +35,36 @@ const SearchResults: React.FC = () => {
     const symptomData = sessionStorage.getItem('symptomData');
     if (symptomData) {
       const data = JSON.parse(symptomData);
-      setSearchParams({ location: data.location, urgency: data.urgency, coordinates: data.coordinates });
-      setFilters(prev => ({ ...prev, insurance: data.insurance || 'any' }));
-      searchClinics({
-        location: data.location,
-        userLocation: data.coordinates,
-        specialty: 'any',
-        insurance: data.insurance || 'any',
-        urgency: data.urgency,
-        maxDistance: 10,
-        minRating: 0
-      });
+      const runSearch = (coords?: { lat: number; lng: number }) => {
+        setSearchParams({ location: data.location, urgency: data.urgency, coordinates: coords });
+        setFilters(prev => ({ ...prev, insurance: data.insurance || 'any' }));
+        searchClinics({
+          location: data.location,
+          userLocation: coords,
+          specialty: 'any',
+          insurance: data.insurance || 'any',
+          urgency: data.urgency,
+          maxDistance: 10,
+          minRating: 0
+        });
+      };
+
+      if (data.coordinates) {
+        runSearch(data.coordinates);
+      } else if (navigator.geolocation) {
+        navigator.geolocation.getCurrentPosition(
+          (position) => {
+            const coords = {
+              lat: position.coords.latitude,
+              lng: position.coords.longitude
+            };
+            runSearch(coords);
+          },
+          () => runSearch(undefined)
+        );
+      } else {
+        runSearch(undefined);
+      }
     }
   }, [searchClinics]);
 

--- a/src/pages/SymptomForm.tsx
+++ b/src/pages/SymptomForm.tsx
@@ -91,18 +91,25 @@ const SymptomForm: React.FC = () => {
     }
   }, [user]);
 
-  // Attempt to auto-detect user location if not already set
+  // Attempt to auto-detect user location with detailed address
   useEffect(() => {
-    if ((!formData.location || !formData.coordinates) && navigator.geolocation) {
+    if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition(async (position) => {
         try {
           const { latitude, longitude } = position.coords;
-          const response = await fetch(`${API_BASE_URL}/location/reverse-geocode?lat=${latitude}&lng=${longitude}`);
+          const response = await fetch(`https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}`);
           const data = await response.json();
-          if (data.success && data.address) {
+          if (data && data.address) {
+            const detailed = [
+              data.address.road,
+              data.address.city || data.address.town || data.address.village,
+              data.address.state,
+              data.address.country,
+              data.address.postcode
+            ].filter(Boolean).join(', ');
             setFormData(prev => ({
               ...prev,
-              location: data.address,
+              location: detailed,
               coordinates: { lat: latitude, lng: longitude }
             }));
           }
@@ -113,7 +120,7 @@ const SymptomForm: React.FC = () => {
         console.error('Geolocation error:', error);
       });
     }
-  }, [formData.location, formData.coordinates]);
+  }, []);
 
   // Geocode address when location changes
   useEffect(() => {
@@ -121,14 +128,14 @@ const SymptomForm: React.FC = () => {
     const timer = setTimeout(async () => {
       if (formData.location) {
         try {
-          const response = await fetch(`${API_BASE_URL}/location/geocode?address=${encodeURIComponent(formData.location)}`, {
+          const response = await fetch(`https://nominatim.openstreetmap.org/search?format=jsonv2&q=${encodeURIComponent(formData.location)}`, {
             signal: controller.signal
           });
           const data = await response.json();
-          if (data.success && data.location) {
+          if (data && data[0]) {
             setFormData(prev => ({
               ...prev,
-              coordinates: { lat: data.location.lat, lng: data.location.lng }
+              coordinates: { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) }
             }));
           }
         } catch (err) {

--- a/src/pages/TriageResults.tsx
+++ b/src/pages/TriageResults.tsx
@@ -103,6 +103,18 @@ const TriageResults: React.FC = () => {
     return 'Within 1-2 weeks';
   };
 
+  const parseSelfCareAdvice = (text: string) => {
+    const sections = text.split(/(?=Do:|Avoid:|Drink:|Eat:)/);
+    const result: Record<string, string> = {};
+    sections.forEach((section) => {
+      const [title, ...rest] = section.split(':');
+      if (rest.length > 0) {
+        result[title.trim().toLowerCase()] = rest.join(':').trim();
+      }
+    });
+    return result;
+  };
+
   const getSelfCareAdvice = (data: SymptomData): string => {
     const symptoms = data.symptoms.toLowerCase();
     if (symptoms.includes('cut') || symptoms.includes('bleeding')) {
@@ -254,7 +266,33 @@ const TriageResults: React.FC = () => {
             <Shield className="w-6 h-6 text-[#1D6FA3]" />
             <span>Self-Care Suggestions</span>
           </h3>
-          <p className="text-gray-700">{triageResult.selfCare}</p>
+          {(() => {
+            const sections = parseSelfCareAdvice(triageResult.selfCare);
+            return (
+              <ul className="list-disc pl-6 text-gray-700 space-y-1">
+                {sections.do && (
+                  <li>
+                    <strong>Do:</strong> {sections.do}
+                  </li>
+                )}
+                {sections.avoid && (
+                  <li>
+                    <strong>Avoid:</strong> {sections.avoid}
+                  </li>
+                )}
+                {sections.drink && (
+                  <li>
+                    <strong>Drink:</strong> {sections.drink}
+                  </li>
+                )}
+                {sections.eat && (
+                  <li>
+                    <strong>Eat:</strong> {sections.eat}
+                  </li>
+                )}
+              </ul>
+            );
+          })()}
         </div>
 
         {/* Emergency Actions */}


### PR DESCRIPTION
## Summary
- Organize self-care advice into clearly labeled sections for better readability
- Add more mock clinics and guarantee at least five nearby providers, using geolocation if needed
- Auto-detect and display detailed user location in the symptom form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous lint errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_688efb4bed948330a1ccb71129804442