### PR TITLE
Handle geocode abort and enable provider filtering

### DIFF
--- a/src/contexts/ClinicContext.tsx
+++ b/src/contexts/ClinicContext.tsx
@@ -194,14 +194,8 @@ export const ClinicProvider: React.FC<{ children: ReactNode }> = ({ children }) 
     // Filter by distance
     filtered = filtered.filter(clinic => clinic.distance <= filters.maxDistance);
 
-    // Ensure at least 5 results by supplementing with closest clinics
-    if (filtered.length < 5) {
-      const sortedByDistance = [...processed].sort((a, b) => a.distance - b.distance);
-      filtered = sortedByDistance.slice(0, 5);
-    } else {
-      // Sort by distance when enough results
-      filtered.sort((a, b) => a.distance - b.distance);
-    }
+    // Sort by distance
+    filtered.sort((a, b) => a.distance - b.distance);
 
     setFilteredClinics(filtered);
   }, [clinics]);

--- a/src/pages/SymptomForm.tsx
+++ b/src/pages/SymptomForm.tsx
@@ -139,7 +139,9 @@ const SymptomForm: React.FC = () => {
             }));
           }
         } catch (err) {
-          console.error('Failed to geocode address', err);
+          if ((err as Error).name !== 'AbortError') {
+            console.error('Failed to geocode address', err);
+          }
         }
       }
     }, 500);


### PR DESCRIPTION
## Summary
- ignore geocoding abort errors to prevent noise
- streamline clinic filtering by removing forced minimum results

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688efef851208330ae7775e2f509d742