### PR TITLE
Add profile editing, custom toast, and improved geocoding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import SearchResults from './pages/SearchResults';
 import BookingPage from './pages/BookingPage';
 import Dashboard from './pages/Dashboard';
 import EmergencyMode from './pages/EmergencyMode';
+import Toaster from './components/ui/Toaster';
 
 function App() {
   return (
@@ -30,6 +31,7 @@ function App() {
                 <Route path="/emergency" element={<EmergencyMode />} />
               </Routes>
             </main>
+            <Toaster />
           </div>
         </Router>
       </ClinicProvider>

--- a/src/components/ui/Toaster.tsx
+++ b/src/components/ui/Toaster.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { ToastContainer, Slide } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+const Toaster: React.FC = () => (
+  <ToastContainer
+    position="top-right"
+    autoClose={3000}
+    hideProgressBar={false}
+    newestOnTop={false}
+    closeOnClick
+    rtl={false}
+    pauseOnFocusLoss
+    draggable
+    pauseOnHover
+    theme="colored"
+    transition={Slide}
+  />
+);
+
+export default Toaster;

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -168,8 +168,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
       localStorage.setItem('mediconnect_token', data.token);
       setUser(data.user);
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error) {
+      setError((error as Error).message);
       throw error;
     } finally {
       setLoading(false);
@@ -197,8 +197,8 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
 
       localStorage.setItem('mediconnect_token', data.token);
       setUser(data.user);
-    } catch (error: any) {
-      setError(error.message);
+    } catch (error) {
+      setError((error as Error).message);
       throw error;
     } finally {
       setLoading(false);
@@ -226,9 +226,9 @@ export const UserProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         throw new Error(data.error || 'Update failed');
       }
 
-      setUser(data.data);
-    } catch (error: any) {
-      setError(error.message);
+      setUser(data.user);
+    } catch (error) {
+      setError((error as Error).message);
       throw error;
     } finally {
       setLoading(false);

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { 
+import {
   Calendar, 
   Clock, 
   MapPin, 
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useClinics } from '../contexts/ClinicContext';
 import { useUser } from '../contexts/UserContext';
+import { toast } from 'react-toastify';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
 
@@ -25,6 +26,8 @@ const BookingPage: React.FC = () => {
   const navigate = useNavigate();
   const { clinics, selectedClinic } = useClinics();
   const { user, isAuthenticated } = useUser();
+  const symptomData = sessionStorage.getItem('symptomData');
+  const selectedInsurance = user?.insurance?.provider || (symptomData ? JSON.parse(symptomData).insurance : '');
   
   const [selectedDate, setSelectedDate] = useState('');
   const [selectedTime, setSelectedTime] = useState('');
@@ -62,7 +65,7 @@ const BookingPage: React.FC = () => {
   const handleBooking = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!isAuthenticated) {
-      alert('Please sign in to book an appointment');
+      toast.error('Please sign in to book an appointment');
       return;
     }
 
@@ -92,7 +95,7 @@ const BookingPage: React.FC = () => {
       setBookingComplete(true);
     } catch (err) {
       console.error('Booking failed', err);
-      alert('Failed to book appointment');
+      toast.error('Failed to book appointment');
     } finally {
       setIsBooking(false);
     }
@@ -344,7 +347,7 @@ const BookingPage: React.FC = () => {
                       <div className="flex items-center space-x-3 p-3 bg-gray-50 rounded-lg">
                         <CreditCard className="w-5 h-5 text-gray-400" />
                         <div>
-                          <div className="font-medium text-gray-900">{user.insurance.provider}</div>
+                          <div className="font-medium text-gray-900">{selectedInsurance}</div>
                           <div className="text-sm text-gray-500">Insurance</div>
                         </div>
                       </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,20 +1,19 @@
-import React, { useState } from 'react';
-import { 
-  Calendar, 
-  Clock, 
-  MapPin, 
-  Phone, 
-  Star, 
+import React, { useState, useEffect } from 'react';
+import {
+  Calendar,
+  Clock,
+  MapPin,
+  Star,
   User,
   Bell,
   Settings,
   CreditCard,
   FileText,
   ChevronRight,
-  Plus,
-  Filter
+  Plus
 } from 'lucide-react';
 import { useUser } from '../contexts/UserContext';
+import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 
 interface Appointment {
@@ -30,8 +29,42 @@ interface Appointment {
 }
 
 const Dashboard: React.FC = () => {
-  const { user, isAuthenticated } = useUser();
+  const { user, isAuthenticated, updateUser } = useUser();
   const [activeTab, setActiveTab] = useState('appointments');
+  const [profile, setProfile] = useState({
+    name: user?.name || '',
+    email: user?.email || '',
+    phone: user?.phone || '',
+    location: user?.location?.address || '',
+    insuranceProvider: user?.insurance?.provider || '',
+    policyNumber: user?.insurance?.policyNumber || ''
+  });
+
+  useEffect(() => {
+    setProfile({
+      name: user?.name || '',
+      email: user?.email || '',
+      phone: user?.phone || '',
+      location: user?.location?.address || '',
+      insuranceProvider: user?.insurance?.provider || '',
+      policyNumber: user?.insurance?.policyNumber || ''
+    });
+  }, [user]);
+
+  const handleSaveProfile = async () => {
+    try {
+      await updateUser({
+        name: profile.name,
+        phone: profile.phone,
+        location: { ...user?.location, address: profile.location },
+        insurance: { ...user?.insurance, provider: profile.insuranceProvider, policyNumber: profile.policyNumber }
+      });
+      toast.success('Profile updated');
+    } catch (error) {
+      console.error(error);
+      toast.error('Failed to update profile');
+    }
+  };
 
   const mockAppointments: Appointment[] = [
     {
@@ -313,38 +346,38 @@ const Dashboard: React.FC = () => {
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Full Name</label>
-                            <input 
-                              type="text" 
-                              value={user?.name || ''} 
+                            <input
+                              type="text"
+                              value={profile.name}
+                              onChange={(e) => setProfile({ ...profile, name: e.target.value })}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              readOnly
                             />
                           </div>
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                            <input 
-                              type="email" 
-                              value={user?.email || ''} 
+                            <input
+                              type="email"
+                              value={profile.email}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                               readOnly
                             />
                           </div>
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Phone</label>
-                            <input 
-                              type="tel" 
-                              value={user?.phone || ''} 
+                            <input
+                              type="tel"
+                              value={profile.phone}
+                              onChange={(e) => setProfile({ ...profile, phone: e.target.value })}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              readOnly
                             />
                           </div>
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Location</label>
-                            <input 
-                              type="text" 
-                              value={user?.location.address || ''} 
+                            <input
+                              type="text"
+                              value={profile.location}
+                              onChange={(e) => setProfile({ ...profile, location: e.target.value })}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              readOnly
                             />
                           </div>
                         </div>
@@ -355,20 +388,20 @@ const Dashboard: React.FC = () => {
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Provider</label>
-                            <input 
-                              type="text" 
-                              value={user?.insurance.provider || ''} 
+                            <input
+                              type="text"
+                              value={profile.insuranceProvider}
+                              onChange={(e) => setProfile({ ...profile, insuranceProvider: e.target.value })}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              readOnly
                             />
                           </div>
                           <div>
                             <label className="block text-sm font-medium text-gray-700 mb-1">Policy Number</label>
-                            <input 
-                              type="text" 
-                              value={user?.insurance.policyNumber || ''} 
+                            <input
+                              type="text"
+                              value={profile.policyNumber}
+                              onChange={(e) => setProfile({ ...profile, policyNumber: e.target.value })}
                               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                              readOnly
                             />
                           </div>
                         </div>
@@ -383,7 +416,16 @@ const Dashboard: React.FC = () => {
                           </label>
                         </div>
                       </div>
-                    </div>
+
+                      <div className="text-right">
+                        <button
+                          onClick={handleSaveProfile}
+                          className="mt-4 bg-[#1D6FA3]/80 text-white px-4 py-2 rounded-lg hover:bg-[#1D6FA3] transition-colors"
+                        >
+                          Save Changes
+                        </button>
+                      </div>
+                      </div>
                   </div>
                 )}
               </div>

--- a/src/pages/SymptomForm.tsx
+++ b/src/pages/SymptomForm.tsx
@@ -48,7 +48,7 @@ interface InsuranceProvider {
 
 const SymptomForm: React.FC = () => {
   const navigate = useNavigate();
-  const { user } = useUser();
+  const { user, updateUser } = useUser();
   const [currentStep, setCurrentStep] = useState(1);
   const [formData, setFormData] = useState<FormData>({
     symptoms: '',
@@ -139,7 +139,7 @@ const SymptomForm: React.FC = () => {
             }));
           }
         } catch (err) {
-          if ((err as Error).name !== 'AbortError') {
+          if (!(err instanceof DOMException && err.name === 'AbortError')) {
             console.error('Failed to geocode address', err);
           }
         }
@@ -256,7 +256,24 @@ const SymptomForm: React.FC = () => {
         uploadedImageIds,
         userId: user?._id
       };
-      
+
+      if (user) {
+        try {
+          await updateUser({
+            location: {
+              address: formData.location,
+              lat: formData.coordinates?.lat || 0,
+              lng: formData.coordinates?.lng || 0
+            },
+            insurance: {
+              provider: formData.insurance
+            }
+          });
+        } catch (err) {
+          console.error('Failed to update profile', err);
+        }
+      }
+
       sessionStorage.setItem('symptomData', JSON.stringify(submissionData));
       navigate('/triage');
     } catch (error) {


### PR DESCRIPTION
## Summary
- handle geocoding aborts and persist location/insurance data from symptom form
- add global colorful toast notifications and replace alert usage
- make account settings editable and save updates to backend

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 206 problems (204 errors, 2 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688f00e2c68c833085c1024213348bd8