### PR TITLE
Allow unverified users to access auth endpoints

### DIFF
--- a/backend/dist/middleware/auth.js
+++ b/backend/dist/middleware/auth.js
@@ -30,12 +30,6 @@ const protect = async (req, res, next) => {
                     error: 'Not authorized to access this resource'
                 });
             }
-            if (!user.isVerified) {
-                return res.status(401).json({
-                    success: false,
-                    error: 'Please verify your email to access this resource'
-                });
-            }
             req.user = user;
             next();
         }
@@ -76,7 +70,7 @@ const optionalAuth = async (req, res, next) => {
             try {
                 const decoded = jsonwebtoken_1.default.verify(token, process.env.JWT_SECRET);
                 const user = await User_1.default.findById(decoded.id);
-                if (user && user.isVerified) {
+                if (user) {
                     req.user = user;
                 }
             }

--- a/backend/src/middleware/auth.ts
+++ b/backend/src/middleware/auth.ts
@@ -94,7 +94,10 @@ const optionalAuth = async (req: AuthRequest, res: Response, next: NextFunction)
       try {
         const decoded = jwt.verify(token, process.env.JWT_SECRET!) as JwtPayload;
         const user = await User.findById(decoded.id);
-        if (user && user.isVerified) {
+        if (user) {
+          // Allow access even if the user's email isn't verified
+          // This prevents 401 errors for users who haven't completed
+          // the verification process yet.
           req.user = user;
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- remove email verification requirement from protect and optionalAuth middleware
- compile backend auth middleware to match source

## Testing
- `npm run build` *(fails: Not all code paths return a value...)*
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: 103 problems (103 errors, 0 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_688f05a170808330aa3a4ba272d21579