### PR TITLE
feat: save and list user appointments

### DIFF
--- a/backend/src/controllers/appointmentController.ts
+++ b/backend/src/controllers/appointmentController.ts
@@ -5,7 +5,7 @@ import { AuthRequest } from '../middleware/auth';
 
 export const createAppointment = async (req: AuthRequest, res: Response, next: NextFunction) => {
   try {
-    const { clinicId, appointmentDate, appointmentTime, type, notes } = req.body;
+    const { clinicId, clinicName, clinicAddress, appointmentDate, appointmentTime, type, notes } = req.body;
 
     const clinicObjectId = mongoose.Types.ObjectId.isValid(clinicId)
       ? new mongoose.Types.ObjectId(clinicId)
@@ -14,6 +14,8 @@ export const createAppointment = async (req: AuthRequest, res: Response, next: N
     const appointment = await Appointment.create({
       user: req.user!._id,
       clinic: clinicObjectId,
+      clinicName,
+      clinicAddress,
       appointmentDate,
       appointmentTime,
       duration: 30,
@@ -35,6 +37,15 @@ export const createAppointment = async (req: AuthRequest, res: Response, next: N
     });
 
     res.status(201).json({ success: true, data: appointment });
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getAppointments = async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const appointments = await Appointment.find({ user: req.user!._id }).sort({ appointmentDate: 1, appointmentTime: 1 });
+    res.status(200).json({ success: true, data: appointments });
   } catch (error) {
     next(error);
   }

--- a/backend/src/models/Appointment.ts
+++ b/backend/src/models/Appointment.ts
@@ -3,6 +3,8 @@ import mongoose, { Document, Schema } from 'mongoose';
 export interface IAppointment extends Document {
   user: mongoose.Types.ObjectId;
   clinic: mongoose.Types.ObjectId;
+  clinicName: string;
+  clinicAddress: string;
   appointmentDate: Date;
   appointmentTime: string;
   duration: number; // in minutes
@@ -59,6 +61,16 @@ const AppointmentSchema = new Schema<IAppointment>({
     type: Schema.Types.ObjectId,
     ref: 'Clinic',
     required: [true, 'Clinic is required']
+  },
+  clinicName: {
+    type: String,
+    required: [true, 'Clinic name is required'],
+    trim: true
+  },
+  clinicAddress: {
+    type: String,
+    required: [true, 'Clinic address is required'],
+    trim: true
   },
   appointmentDate: {
     type: Date,

--- a/backend/src/routes/appointment.ts
+++ b/backend/src/routes/appointment.ts
@@ -1,8 +1,11 @@
 import express from 'express';
 import { protect } from '../middleware/auth';
-import { createAppointment } from '../controllers/appointmentController';
+import { createAppointment, getAppointments } from '../controllers/appointmentController';
 
 const router = express.Router();
+
+// Get all appointments for the authenticated user
+router.get('/', protect, getAppointments);
 
 // Create a new appointment
 router.post('/', protect, createAppointment);

--- a/src/pages/BookingPage.tsx
+++ b/src/pages/BookingPage.tsx
@@ -81,6 +81,8 @@ const BookingPage: React.FC = () => {
         },
         body: JSON.stringify({
           clinicId: clinic.id,
+          clinicName: clinic.name,
+          clinicAddress: clinic.address,
           appointmentDate: selectedDate,
           appointmentTime: selectedTime,
           type: appointmentType,
@@ -101,13 +103,11 @@ const BookingPage: React.FC = () => {
     }
   };
 
-  const availableDates = [
-    '2024-01-15',
-    '2024-01-16',
-    '2024-01-17',
-    '2024-01-18',
-    '2024-01-19'
-  ];
+  const availableDates = Array.from({ length: 5 }, (_, i) => {
+    const date = new Date();
+    date.setDate(date.getDate() + i + 1);
+    return date.toISOString().split('T')[0];
+  });
 
   const availableTimes = [
     '09:00', '09:30', '10:00', '10:30', '11:00', '11:30',

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,7 +5,6 @@ import {
   MapPin,
   Star,
   User,
-  Bell,
   Settings,
   CreditCard,
   FileText,
@@ -16,21 +15,22 @@ import { useUser } from '../contexts/UserContext';
 import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000/api';
+
 interface Appointment {
-  id: string;
+  _id: string;
   clinicName: string;
   clinicAddress: string;
-  date: string;
-  time: string;
+  appointmentDate: string;
+  appointmentTime: string;
   type: string;
-  status: 'upcoming' | 'completed' | 'cancelled';
-  doctor: string;
-  cost: number;
+  status: string;
 }
 
 const Dashboard: React.FC = () => {
   const { user, isAuthenticated, updateUser } = useUser();
   const [activeTab, setActiveTab] = useState('appointments');
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
   const [profile, setProfile] = useState({
     name: user?.name || '',
     email: user?.email || '',
@@ -66,41 +66,27 @@ const Dashboard: React.FC = () => {
     }
   };
 
-  const mockAppointments: Appointment[] = [
-    {
-      id: '1',
-      clinicName: 'Manhattan General Hospital',
-      clinicAddress: '123 Medical Center Dr, New York, NY',
-      date: '2025-09-15',
-      time: '09:00',
-      type: 'General Consultation',
-      status: 'upcoming',
-      doctor: 'Dr. Sarah Johnson',
-      cost: 180
-    },
-    {
-      id: '2',
-      clinicName: 'CityMed Urgent Care',
-      clinicAddress: '456 Health Plaza, New York, NY',
-      date: '2025-8-10',
-      time: '14:30',
-      type: 'Follow-up',
-      status: 'completed',
-      doctor: 'Dr. Michael Chen',
-      cost: 120
-    },
-    {
-      id: '3',
-      clinicName: 'Downtown Family Clinic',
-      clinicAddress: '789 Wellness Ave, New York, NY',
-      date: '2025-10-20',
-      time: '11:00',
-      type: 'Specialist Visit',
-      status: 'upcoming',
-      doctor: 'Dr. Emily Rodriguez',
-      cost: 250
+  useEffect(() => {
+    const fetchAppointments = async () => {
+      try {
+        const token = localStorage.getItem('mediconnect_token');
+        const response = await fetch(`${API_BASE_URL}/appointments`, {
+          headers: {
+            'Authorization': `Bearer ${token}`
+          }
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setAppointments(data.data || []);
+        }
+      } catch (error) {
+        console.error('Failed to fetch appointments', error);
+      }
+    };
+    if (isAuthenticated) {
+      fetchAppointments();
     }
-  ];
+  }, [isAuthenticated]);
 
   if (!isAuthenticated) {
     return (
@@ -117,15 +103,20 @@ const Dashboard: React.FC = () => {
     );
   }
 
-  const upcomingAppointments = mockAppointments.filter(apt => apt.status === 'upcoming');
-  const completedAppointments = mockAppointments.filter(apt => apt.status === 'completed');
+  const upcomingAppointments = appointments.filter(apt => apt.status !== 'completed' && apt.status !== 'cancelled');
+  const completedAppointments = appointments.filter(apt => apt.status === 'completed');
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'upcoming': return 'blue';
-      case 'completed': return 'green';
-      case 'cancelled': return 'red';
-      default: return 'gray';
+      case 'scheduled':
+      case 'confirmed':
+        return 'blue';
+      case 'completed':
+        return 'green';
+      case 'cancelled':
+        return 'red';
+      default:
+        return 'gray';
     }
   };
 
@@ -240,7 +231,7 @@ const Dashboard: React.FC = () => {
 
                     <div className="space-y-4">
                       {upcomingAppointments.map((appointment) => (
-                        <div key={appointment.id} className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
+                        <div key={appointment._id} className="border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow">
                           <div className="flex items-center justify-between">
                             <div className="flex-1">
                               <div className="flex items-center space-x-3 mb-2">
@@ -249,32 +240,24 @@ const Dashboard: React.FC = () => {
                                   {appointment.status}
                                 </span>
                               </div>
-                              
+
                               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
                                 <div className="flex items-center space-x-2">
                                   <Calendar className="w-4 h-4" />
-                                  <span>{new Date(appointment.date).toLocaleDateString()}</span>
+                                  <span>{new Date(appointment.appointmentDate).toLocaleDateString()}</span>
                                 </div>
                                 <div className="flex items-center space-x-2">
                                   <Clock className="w-4 h-4" />
-                                  <span>{appointment.time}</span>
-                                </div>
-                                <div className="flex items-center space-x-2">
-                                  <User className="w-4 h-4" />
-                                  <span>{appointment.doctor}</span>
-                                </div>
-                                <div className="flex items-center space-x-2">
-                                  <CreditCard className="w-4 h-4" />
-                                  <span>${appointment.cost}</span>
+                                  <span>{appointment.appointmentTime}</span>
                                 </div>
                               </div>
-                              
+
                               <div className="flex items-center space-x-2 mt-2 text-sm text-gray-500">
                                 <MapPin className="w-4 h-4" />
                                 <span>{appointment.clinicAddress}</span>
                               </div>
                             </div>
-                            
+
                             <div className="flex items-center space-x-2">
                               <button className="p-2 text-gray-400 hover:text-blue-600 transition-colors">
                                 <ChevronRight className="w-4 h-4" />
@@ -300,7 +283,7 @@ const Dashboard: React.FC = () => {
 
                     <div className="space-y-4">
                       {completedAppointments.map((appointment) => (
-                        <div key={appointment.id} className="border border-gray-200 rounded-lg p-4">
+                        <div key={appointment._id} className="border border-gray-200 rounded-lg p-4">
                           <div className="flex items-center justify-between">
                             <div className="flex-1">
                               <div className="flex items-center space-x-3 mb-2">
@@ -309,24 +292,17 @@ const Dashboard: React.FC = () => {
                                   {appointment.status}
                                 </span>
                               </div>
-                              
+
                               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-600">
                                 <div className="flex items-center space-x-2">
                                   <Calendar className="w-4 h-4" />
-                                  <span>{new Date(appointment.date).toLocaleDateString()}</span>
+                                  <span>{new Date(appointment.appointmentDate).toLocaleDateString()}</span>
                                 </div>
                                 <div className="flex items-center space-x-2">
-                                  <User className="w-4 h-4" />
-                                  <span>{appointment.doctor}</span>
+                                  <Clock className="w-4 h-4" />
+                                  <span>{appointment.appointmentTime}</span>
                                 </div>
                               </div>
-                            </div>
-                            
-                            <div className="text-right">
-                              <div className="text-lg font-semibold text-gray-900">${appointment.cost}</div>
-                              <button className="text-sm text-[#1D6FA3] hover:text-[#1D6FA3]/80">
-                                View Details
-                              </button>
                             </div>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- store clinic details in Appointment model and expose user appointments API
- send clinic info from Booking page with future date selection
- dashboard fetches and displays booked appointments

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` (backend) *(fails: Unexpected any...)*
- `npm run lint` *(frontend) (fails: unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_688f104ecf148330a8fd6e79d9d0df2d